### PR TITLE
Preserve External Node ID Conventions in Tour.set_nodes()

### DIFF
--- a/src/lk_heuristic/models/tour.py
+++ b/src/lk_heuristic/models/tour.py
@@ -60,7 +60,7 @@ class Tour:
             self.nodes[i].pred = self.nodes[i - 1]
 
             self.nodes[i].pos = i
-            self.nodes[i].id = i
+            # self.nodes[i].id = i
 
     def set_edges(self):
         """


### PR DESCRIPTION
The node.id is currently reset to start at 0, which leads to errors when loading TSPLIB instances that use different node numbering when loading an instance. For example, node IDs in burma14 begin at 1. Since there appears to be no compelling reason to reset the node ID, I recommend removing this line to ensure compatibility with such datasets.